### PR TITLE
Improve download script to detect when no new episodes available

### DIFF
--- a/download_new_episodes.py
+++ b/download_new_episodes.py
@@ -63,23 +63,31 @@ def download_and_save(game_id, output_dir):
 def download_range(start_id, end_id, output_dir):
     """Download a range of games."""
     os.makedirs(output_dir, exist_ok=True)
-    
-    total = end_id - start_id + 1
+
+    # First, probe to find the actual end
+    print(f"Probing for latest episode starting from {start_id}...")
+    actual_end = find_last_available(start_id, end_id)
+
+    if actual_end < start_id:
+        print(f"No new episodes found. Archive is up to date at episode {start_id - 1}.")
+        return 0, []
+
+    total = actual_end - start_id + 1
     completed = 0
     failed = []
-    
-    print(f"Downloading games {start_id} to {end_id} ({total} total)")
+
+    print(f"Downloading games {start_id} to {actual_end} ({total} total)")
     print(f"Using {NUM_THREADS} threads with {SECONDS_BETWEEN_REQUESTS}s delay")
     print(f"Estimated time: ~{(total * SECONDS_BETWEEN_REQUESTS) / (NUM_THREADS * 60):.1f} minutes")
     print("-" * 60)
-    
+
     with futures.ThreadPoolExecutor(max_workers=NUM_THREADS) as executor:
         # Submit all jobs
         future_to_id = {
-            executor.submit(download_and_save, gid, output_dir): gid 
-            for gid in range(start_id, end_id + 1)
+            executor.submit(download_and_save, gid, output_dir): gid
+            for gid in range(start_id, actual_end + 1)
         }
-        
+
         # Process as they complete
         for future in futures.as_completed(future_to_id):
             game_id = future_to_id[future]
@@ -89,21 +97,58 @@ def download_range(start_id, end_id, output_dir):
                     completed += 1
                 else:
                     failed.append(game_id)
-                
-                if completed % 50 == 0:
+
+                if completed > 0 and completed % 50 == 0:
                     print(f"Progress: {completed}/{total} completed ({completed/total*100:.1f}%)")
             except Exception as e:
                 print(f"Exception for game {game_id}: {e}")
                 failed.append(game_id)
-    
+
     print("-" * 60)
     print(f"Download complete!")
     print(f"Successfully downloaded: {completed}")
     print(f"Failed: {len(failed)}")
     if failed:
         print(f"Failed game IDs: {failed[:10]}{'...' if len(failed) > 10 else ''}")
-    
+
     return completed, failed
+
+def find_last_available(start_id, max_id):
+    """Find the last available episode using binary search-like probing."""
+    # First check if start_id exists
+    if not check_game_exists(start_id):
+        return start_id - 1
+
+    # Do a quick probe forward to find approximate end
+    probe = start_id
+    step = 50
+
+    while probe <= max_id:
+        if check_game_exists(probe):
+            probe += step
+        else:
+            # Found a gap, search backward
+            break
+
+    # Now find exact end by checking backwards
+    end = probe - step
+    for i in range(probe - 1, end, -1):
+        if check_game_exists(i):
+            return i
+
+    return end
+
+def check_game_exists(game_id):
+    """Quick check if a game exists without downloading."""
+    url = f'http://j-archive.com/showgame.php?game_id={game_id}'
+    try:
+        response = urlopen(url)
+        if response.code == 200:
+            html = response.read()
+            return ERROR_MSG not in html
+    except:
+        pass
+    return False
 
 if __name__ == "__main__":
     if len(sys.argv) != 4:


### PR DESCRIPTION
- Add probing mechanism to find last available episode before downloading
- Use binary search approach to quickly detect episode range
- Prevents attempting to download hundreds of non-existent episodes
- Exit gracefully when archive is already up to date

This fixes the workflow showing failures when simply no new episodes have aired yet.